### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@ flask-tutorial
 ==============
 
 
-#What is Flask ?
+# What is Flask ?
 Flask is a microframework for Python based on Werkzeug, Jinja 2 and good intentions.
 
-#tutorial
+# tutorial
 Source code for video tutorial series
 https://www.youtube.com/playlist?list=PL0DA14EB3618A3507
 
 
-#ما هو Flask ?
+# ما هو Flask ?
 
 flask هو اطار عمل صغير للغة Python مبني على اساس Werkzeug, Jinja 2 و good intentions.
 
-#دورة تعليمية
+# دورة تعليمية
 
 الكود المصدري لسلسلة دروس الفيديو.
 https://www.youtube.com/playlist?list=PL0DA14EB3618A3507


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
